### PR TITLE
Add initial issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug Report 🐞
+about: Create a report to help us improve.
+labels: 'bug'
+---
+
+## Describe the bug
+
+A clear and concise description of the issue.
+
+## Steps to reproduce
+
+Steps to reproduce the behavior:
+
+1. ...
+2. ...
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Current behavior
+
+A clear and concise description of what happened instead.
+
+## Additional Information
+
+Any additional information to give context to the issue.
+* Python version
+* `pyserial` version
+* Operating System version
+* Hardware details

--- a/.github/ISSUE_TEMPLATE/feature_suggestion.md
+++ b/.github/ISSUE_TEMPLATE/feature_suggestion.md
@@ -1,0 +1,13 @@
+---
+name: Feature Suggestion 💡
+about: Suggest an idea for the project.
+labels: 'feature-suggestion'
+---
+
+## Summary
+
+A brief explanation of the feature.
+
+### Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?


### PR DESCRIPTION
## Description
Adds [issue templates](https://docs.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates#issue-templates) to GitHub repository for:
* Bug Report
* Feature Suggestion

## Testing
- [x] Review markdown files
