### PR TITLE
Support several ansi text modes to highlight data bytes which were replaced during replay.

### DIFF
--- a/akheron.py
+++ b/akheron.py
@@ -1124,9 +1124,9 @@ Usage: textmodeget
         """
 Description: set text mode for terminal output
 
-Usage:	textmode <replaced> <invert | underline | bold>
+Usage:	textmodeset <replaced> <invert | underline | bold>
 
-Example(s): textmode replaced invert
+Example(s): textmodeset replaced invert
         """
         textmode_set(arg.split())
 

--- a/akheron.py
+++ b/akheron.py
@@ -3,7 +3,7 @@
 # akheron - UART proxy tool for inter-chip analysis, capturing, replaying, and
 # modifying UART data!
 #
-# Copyright 2020
+# Copyright 2020, 2021
 
 import argparse
 import cmd
@@ -12,6 +12,7 @@ import operator
 import os.path
 import threading
 from enum import Enum, auto
+from typing import NamedTuple
 from time import sleep
 
 import serial
@@ -31,16 +32,26 @@ class SupportedChecksums(Enum):
     Checksum8Modulo256Plus1 = auto()
     Checksum82sComplement = auto()
 
-class teeOutputs(Enum):
+class TeeOutput(Enum):
     onlyDisplay = auto()
     onlyFile = auto()
     both = auto()
 
+class TextRangeDisplayMode(NamedTuple):
+    start: int
+    end: int
+    mode: str
 
 # Globals #####
 version = "0.1"
 histfile = os.path.join(os.path.expanduser("~"), ".akheron_history")
 histsize = 1000
+ansi_text = {
+    "reset":     "\033[0m",
+    "bold":      "\033[1m",
+    "underline": "\033[4m",
+    "invert":    "\033[7m",
+}
 
 # Port settings, as provided via the 'portset' command.
 portSettings = {
@@ -71,6 +82,11 @@ replacePatterns = {
 replaceChecksums = {
     "A": None,
     "B": None
+}
+
+# Terminal text mode to make certain text more "visually obvious".
+textMode = {
+    "replaced": "none"
 }
 
 # Temp buffers for holding incoming (RX'd) data to check against msgDelims.
@@ -353,19 +369,26 @@ def checksum_set(args=""):
 def replace_patterns_if_matched(data, patterns, checksum_method):
     if len(patterns) == 0:
         # No patterns to match on, we're done
-        return data
+        return data, None
+    updated_text_mode_ranges = []
     for k, v in patterns.items():
         k_list = k.split(" ")
         match_list = [int(i, 16) for i in k_list]
         len_ml = len(match_list)
-        for i in range(len(data) - len_ml + 1):
+        i = 0
+        while i < (len(data) - len_ml + 1):
             if match_list == data[i:i + len_ml]:
                 data[i:i + len_ml] = [int(val, 16) for val in v]
+                if textMode["replaced"] != "none":
+                    # Start index, stop index, and the text mode to use for this range...
+                    updated_text_mode_ranges.append(TextRangeDisplayMode(i, i + len_ml, textMode["replaced"]))
                 checksum = calculate_checksum(data[:-1], checksum_method)
                 if checksum is not None:
                     data[-1] = checksum
-                break
-    return data
+                i += len(v)
+            else:
+                i += 1
+    return data, updated_text_mode_ranges
 
 
 def calculate_checksum(data, checksum_method):
@@ -422,11 +445,11 @@ def check_msg(port, start_or_end, byte=None):
 # string: string value to display+write
 # end: trailing character for 'string'
 # Returns: n/a
-def tee(string="", end="\n", output=teeOutputs['both']):
+def tee(string="", end="\n", output=TeeOutput.both):
     with teeLock:
         global captureFileSize
 
-        if captureFile and output != teeOutputs.onlyDisplay:
+        if captureFile and output != TeeOutput.onlyDisplay:
             if len(string) > 0 and string[0] == "\b":
                 # Need to erase some previously-written bytes due to a msg delimiter.
                 if captureFileSize >= len(string):
@@ -439,7 +462,7 @@ def tee(string="", end="\n", output=teeOutputs['both']):
                 captureFile.flush()
                 captureFileSize += len(string) + len(end)
 
-        if watching and output != teeOutputs.onlyFile:
+        if watching and output != TeeOutput.onlyFile:
             print(string, end=end, flush=True)
 
 
@@ -514,6 +537,28 @@ def dump_capture(args=""):
     for line in dump_file_contents:
         print("%5u: %s" % (line_num, line.rstrip()))
         line_num += 1
+
+def updated_text_output_str(data, updated_text_mode_ranges):
+    outstr = ""
+    index = 0
+    if updated_text_mode_ranges and len(updated_text_mode_ranges) > 0:
+        for b in data:
+            for r in updated_text_mode_ranges:
+                if r.start == index:
+                    # Reached the start of a range of replaced text, set to colorized text...
+                    outstr += ansi_text[r.mode]
+                    break
+            outstr += format("0x%02x" % int(b))
+            for r in updated_text_mode_ranges:
+                if r.end == index:
+                    # Reached the end of a range of replaced text, reset to normal text...
+                    outstr += ansi_text["reset"]
+                    break
+            outstr += " "
+            index += 1
+    else:
+        outstr = " ".join(format("0x%02x" % int(n)) for n in data) + " "
+    return outstr
 
 
 # Replaying traffic between two ports.
@@ -597,9 +642,10 @@ def replay_traffic(args=""):
                 curr_direction = line[0:start_index - 1]
             if line_num in lines and curr_direction == direction:
                 line_data = list(map(lambda b: int(b, 16), line[start_index:].rstrip().split()))
-                line_data = replace_patterns_if_matched(line_data, replacePatterns[p], replaceChecksums[p])
+                line_data, updated_text_mode_ranges = replace_patterns_if_matched(line_data, replacePatterns[p], replaceChecksums[p])
                 processor.write(out_dev_id, bytes(line_data))
-                tee("\n%s: %s" % (direction, " ".join(format("0x%02x" % int(n)) for n in line_data) + " "), "")
+                tee("\n%s: %s" % (direction, " ".join(format("0x%02x" % int(n)) for n in line_data) + " "), "", TeeOutput.onlyFile)
+                tee("\n%s: %s" % (direction, updated_text_output_str(line_data, updated_text_mode_ranges)), "", TeeOutput.onlyDisplay)
             line_num += 1
         global lastPrinted
         lastPrinted = p
@@ -657,12 +703,12 @@ def data_received_callback(data, p):
                 if watchingStarted == True:
                     # This is the first byte since we started watching the stream, print the direction
                     # to the terminal output...
-                    tee(data_direction_str(p, outp), "", teeOutputs.onlyDisplay)
+                    tee(data_direction_str(p, outp), "", TeeOutput.onlyDisplay)
                     watchingStarted = False
                 if captureStarted == True:
                     # This is the first byte since we started capturing the stream, print the direction
                     # to the terminal output...
-                    tee(data_direction_str(p, outp), "", teeOutputs.onlyFile)
+                    tee(data_direction_str(p, outp), "", TeeOutput.onlyFile)
                     captureStarted = False
                 if len(delimMatched[p]["end"]) > 0:
                     # The previous byte we looked at matched an end-of-message delim, go to new line.
@@ -804,6 +850,40 @@ def watch(args=""):
     global watchingStarted
     print("Watching data passed between ports. Press CTRL-C to stop...")
     watching = watchingStarted = True
+
+
+# 'textmodeget' command, allows user to output the current terminal text mode
+# Returns: n/a
+def textmode_get(args=""):
+    for m in textMode:
+        print(f"{m}: {textMode[m]}")
+
+
+# 'textmodeset' command, allows user to set terminal text mode for different operations
+# args:
+#   [0]: specifies the operation to set the textmode for
+#   [1]: specifies the supported text mode
+# Returns: n/a
+def textmode_set(args=""):
+    global textMode
+
+    if len(args) < 1:
+        print("Incorrect number of args, type \"help\" for usage")
+        return
+    operation = args[0]
+    if operation not in textMode:
+        print("Invalid \"operation\" value, type \"help\" for usage")
+        return
+    if len(args) == 2:
+        mode = args[1]
+        if mode not in ansi_text:
+            print("Invalid \"mode\" value, type \"help\" for usage")
+            return
+    else:
+        mode = "none"
+
+    textMode[operation] = mode
+    return
 
 
 def shutdown():
@@ -1031,6 +1111,24 @@ Usage:	watch
         """
         watch(arg.split())
         watch_wait_exit()
+
+    def do_textmodeget(self, arg):
+        """
+Description: output the current text mode for terminal output
+
+Usage: textmodeget
+        """
+        textmode_get(arg.split())
+
+    def do_textmodeset(self, arg):
+        """
+Description: set text mode for terminal output
+
+Usage:	textmode <replaced> <invert | underline | bold>
+
+Example(s): textmode replaced invert
+        """
+        textmode_set(arg.split())
 
     def do_version(self, arg):
         print("v%s" % version)


### PR DESCRIPTION
## Description

Added support for 'invert', 'underline', and 'bold' text modes for bytes patterns which are replaced during a `replay` operation.

Also fixed a bug in replace logic which only replaced the first instance of a pattern match in a stream.  Now it will replace all instances of a pattern match.

Currently, this covers data bytes replaced, not updated checksum (we could add that!).

NOTE: this is based off the `fix/print-direction-on-watch` branch of work.

## Testing

Ensure all three modes work as-expected, and that using `textmode replaced` resets the highlighting mode to no longer highlight.

<img width="603" alt="Screen Shot 2021-05-03 at 12 42 20 PM" src="https://user-images.githubusercontent.com/19912177/116911840-026a3800-ac0d-11eb-847b-beedc43029c8.png">

