### PR TITLE
Add exclude delimiter option to checksum computation

### DIFF
--- a/akheron.py
+++ b/akheron.py
@@ -43,7 +43,7 @@ class TextRangeDisplayMode(NamedTuple):
     mode: str
 
 # Globals #####
-version = "0.1"
+version = "0.2"
 histfile = os.path.join(os.path.expanduser("~"), ".akheron_history")
 histsize = 1000
 ansi_text = {


### PR DESCRIPTION
## Description
Adds the option to exclude the start delimiter from checksum recalculation that is performed after a message replace pattern is applied.

## Testing
- [ ] Start `akheron.py`
- [ ] Configure ports
- [ ] Set a start delimiter using `delimset start`
- [ ] Set a replacement pattern using `replaceset`
- [ ] Set checksum recalculation using `checksumset` with no 3rd parameter. This will perform the existing behavior of including the start delimiter in the checksum recalculation.
  - [ ] Replay data previously captured using `replay`
  - [ ] **Verify** the replacement and checksum recalculation is correctly computed and includes the start delimiter
- [ ] Set checksum recalculation using `checksumset` with the 3rd parameter `true` to exclude the start delimiter in the checksum recalculation. 
  - [ ] Replay data previously captured using `replay`
  - [ ] **Verify** the replacement and checksum recalculation is correctly computed and excludes the start delimiter
