### PR TITLE
Update pyserial to version 3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyserial==3.4
+pyserial==3.5


### PR DESCRIPTION
## Description
Updates `pyserial` package to version 3.5.

## Testing

* Successfully tested on macOS 15.3 with Python 3.12.9.
* Changes need to be tested on Linux

### Steps
- [x] Connect four hardware serial devices with TX-RX attached appropriately
- [x] Start two miniterms configured on the appropriate serial devices to act as communication endpoints (`python -m serial.tools.miniterm <serial device> 115200`)
- [x] Start `akheron.py`
- [x] **Verify** the `list` command lists available serial devices
- [x] Configure port A and B using the `portset` command
- [x] Start forwarding UART traffic using the `start` command
- [x] Start watching UART traffic using the `watch` command
- [x] Enter data in the port A side miniterm
- [x] Verify data is displayed in akheron and passed through to the port B side miniterm
- [x] Enter data in the port B side miniterm
- [x] Verify data is displayed in akheron and passed through to the port A side miniterm
- [x] Press CTRL-C to stop watching data
- [x] Stop forwarding UART traffic using the `stop` command